### PR TITLE
Add valid ESPI port RAM lengths

### DIFF
--- a/patch/espi.yaml
+++ b/patch/espi.yaml
@@ -54,6 +54,15 @@ ESPI:
       P[01234]RAMUse:
         description: Port RAM base and size (for Mailbox and Bus Master)
         name: RAMUSE
+        LEN:
+          LEN_4: [0, 4 bytes]
+          LEN_8: [1, 8 bytes]
+          LEN_16: [2, 16 bytes]
+          LEN_32: [3, 32 bytes]
+          LEN_64: [4, 64 bytes]
+          LEN_128: [5, 128 bytes]
+          LEN_256: [6, 256 bytes]
+          LEN_512: [7, 512 bytes]
 
   # Add per-port enable bit in MCTRL
   MCTRL:
@@ -119,4 +128,3 @@ ESPI:
 
       GPIO:
         modifiedWriteValues: oneToClear
-

--- a/src/espi/port/ramuse.rs
+++ b/src/espi/port/ramuse.rs
@@ -6,10 +6,145 @@ pub type W = crate::W<RamuseSpec>;
 pub type OffR = crate::FieldReader<u16>;
 #[doc = "Field `OFF` writer - This is the word offset into the RAM"]
 pub type OffW<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
+#[doc = "This is the length of the mailbox or mastering area as 4<<LEN per direction\n\nValue on reset: 0"]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Len {
+    #[doc = "0: 4 bytes"]
+    Len4 = 0,
+    #[doc = "1: 8 bytes"]
+    Len8 = 1,
+    #[doc = "2: 16 bytes"]
+    Len16 = 2,
+    #[doc = "3: 32 bytes"]
+    Len32 = 3,
+    #[doc = "4: 64 bytes"]
+    Len64 = 4,
+    #[doc = "5: 128 bytes"]
+    Len128 = 5,
+    #[doc = "6: 256 bytes"]
+    Len256 = 6,
+    #[doc = "7: 512 bytes"]
+    Len512 = 7,
+}
+impl From<Len> for u8 {
+    #[inline(always)]
+    fn from(variant: Len) -> Self {
+        variant as _
+    }
+}
+impl crate::FieldSpec for Len {
+    type Ux = u8;
+}
+impl crate::IsEnum for Len {}
 #[doc = "Field `LEN` reader - This is the length of the mailbox or mastering area as 4<<LEN per direction"]
-pub type LenR = crate::FieldReader;
+pub type LenR = crate::FieldReader<Len>;
+impl LenR {
+    #[doc = "Get enumerated values variant"]
+    #[inline(always)]
+    pub const fn variant(&self) -> Len {
+        match self.bits {
+            0 => Len::Len4,
+            1 => Len::Len8,
+            2 => Len::Len16,
+            3 => Len::Len32,
+            4 => Len::Len64,
+            5 => Len::Len128,
+            6 => Len::Len256,
+            7 => Len::Len512,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "4 bytes"]
+    #[inline(always)]
+    pub fn is_len_4(&self) -> bool {
+        *self == Len::Len4
+    }
+    #[doc = "8 bytes"]
+    #[inline(always)]
+    pub fn is_len_8(&self) -> bool {
+        *self == Len::Len8
+    }
+    #[doc = "16 bytes"]
+    #[inline(always)]
+    pub fn is_len_16(&self) -> bool {
+        *self == Len::Len16
+    }
+    #[doc = "32 bytes"]
+    #[inline(always)]
+    pub fn is_len_32(&self) -> bool {
+        *self == Len::Len32
+    }
+    #[doc = "64 bytes"]
+    #[inline(always)]
+    pub fn is_len_64(&self) -> bool {
+        *self == Len::Len64
+    }
+    #[doc = "128 bytes"]
+    #[inline(always)]
+    pub fn is_len_128(&self) -> bool {
+        *self == Len::Len128
+    }
+    #[doc = "256 bytes"]
+    #[inline(always)]
+    pub fn is_len_256(&self) -> bool {
+        *self == Len::Len256
+    }
+    #[doc = "512 bytes"]
+    #[inline(always)]
+    pub fn is_len_512(&self) -> bool {
+        *self == Len::Len512
+    }
+}
 #[doc = "Field `LEN` writer - This is the length of the mailbox or mastering area as 4<<LEN per direction"]
-pub type LenW<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+pub type LenW<'a, REG> = crate::FieldWriter<'a, REG, 3, Len, crate::Safe>;
+impl<'a, REG> LenW<'a, REG>
+where
+    REG: crate::Writable + crate::RegisterSpec,
+    REG::Ux: From<u8>,
+{
+    #[doc = "4 bytes"]
+    #[inline(always)]
+    pub fn len_4(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len4)
+    }
+    #[doc = "8 bytes"]
+    #[inline(always)]
+    pub fn len_8(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len8)
+    }
+    #[doc = "16 bytes"]
+    #[inline(always)]
+    pub fn len_16(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len16)
+    }
+    #[doc = "32 bytes"]
+    #[inline(always)]
+    pub fn len_32(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len32)
+    }
+    #[doc = "64 bytes"]
+    #[inline(always)]
+    pub fn len_64(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len64)
+    }
+    #[doc = "128 bytes"]
+    #[inline(always)]
+    pub fn len_128(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len128)
+    }
+    #[doc = "256 bytes"]
+    #[inline(always)]
+    pub fn len_256(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len256)
+    }
+    #[doc = "512 bytes"]
+    #[inline(always)]
+    pub fn len_512(self) -> &'a mut crate::W<REG> {
+        self.variant(Len::Len512)
+    }
+}
 impl R {
     #[doc = "Bits 0:11 - This is the word offset into the RAM"]
     #[inline(always)]


### PR DESCRIPTION
There so few valid port lengths that we can create an enum for all variants. With this, the user is unable to pass an invalid port length.