### PR TITLE
espi: PnSTAT: add W1C bits correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mimxrt633s-pac"
-version = "0.2.1"
+version = "0.2.2"
 authors = [ "Felipe Balbi <febalbi@microsoft.com>" ]
 edition = "2021"
 license = "MIT"

--- a/patch/espi.yaml
+++ b/patch/espi.yaml
@@ -24,10 +24,40 @@ ESPI:
       P[01234]STAT:
         description: Port Status
         name: STAT
-        _split:
-          INTSPC:
-            name: INTSPC%s
-      
+        _delete:
+          - INTSPC
+
+        _add:
+          INTSPC0:
+            bitOffset: 11
+            bitWidth: 1
+            modifiedWriteValues: oneToClear
+
+          INTSPC1:
+            bitOffset: 12
+            bitWidth: 1
+            modifiedWriteValues: oneToClear
+
+          INTSPC2:
+            bitOffset: 13
+            bitWidth: 1
+            modifiedWriteValues: oneToClear
+
+          INTSPC3:
+            bitOffset: 14
+            bitWidth: 1
+            modifiedWriteValues: oneToClear
+
+        _modify:
+          INTERR:
+            modifiedWriteValues: oneToClear
+
+          INTRD:
+            modifiedWriteValues: oneToClear
+
+          INTWR:
+            modifiedWriteValues: oneToClear
+
       P[01234]IRuleStat:
         description: Port set interrupt rules and user status
         name: IRULESTAT

--- a/src/espi/port/stat.rs
+++ b/src/espi/port/stat.rs
@@ -9,31 +9,31 @@ pub type WrstatR = crate::FieldReader;
 #[doc = "Field `INTERR` reader - Interrupt was caused by error"]
 pub type InterrR = crate::BitReader;
 #[doc = "Field `INTERR` writer - Interrupt was caused by error"]
-pub type InterrW<'a, REG> = crate::BitWriter<'a, REG>;
+pub type InterrW<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `INTRD` reader - Interrupt was caused by Read or 1st Read or Bus master Started."]
 pub type IntrdR = crate::BitReader;
 #[doc = "Field `INTRD` writer - Interrupt was caused by Read or 1st Read or Bus master Started."]
-pub type IntrdW<'a, REG> = crate::BitWriter<'a, REG>;
+pub type IntrdW<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `INTWR` reader - Interrupt was caused by Write or 1st Write or Bus master Started."]
 pub type IntwrR = crate::BitReader;
 #[doc = "Field `INTWR` writer - Interrupt was caused by Write or 1st Write or Bus master Started."]
-pub type IntwrW<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `INTSPC0` reader - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+pub type IntwrW<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `INTSPC0` reader - "]
 pub type Intspc0R = crate::BitReader;
-#[doc = "Field `INTSPC0` writer - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
-pub type Intspc0W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `INTSPC1` reader - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+#[doc = "Field `INTSPC0` writer - "]
+pub type Intspc0W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `INTSPC1` reader - "]
 pub type Intspc1R = crate::BitReader;
-#[doc = "Field `INTSPC1` writer - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
-pub type Intspc1W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `INTSPC2` reader - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+#[doc = "Field `INTSPC1` writer - "]
+pub type Intspc1W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `INTSPC2` reader - "]
 pub type Intspc2R = crate::BitReader;
-#[doc = "Field `INTSPC2` writer - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
-pub type Intspc2W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `INTSPC3` reader - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+#[doc = "Field `INTSPC2` writer - "]
+pub type Intspc2W<'a, REG> = crate::BitWriter1C<'a, REG>;
+#[doc = "Field `INTSPC3` reader - "]
 pub type Intspc3R = crate::BitReader;
-#[doc = "Field `INTSPC3` writer - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
-pub type Intspc3W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `INTSPC3` writer - "]
+pub type Intspc3W<'a, REG> = crate::BitWriter1C<'a, REG>;
 #[doc = "Field `ERR` reader - Cause of INTERR: Bit Endpoint, Idx/Data Mbox BusMaster/Flash ERR0 Host Write Over Host Write or Read invalid for Access Failed From-Host (cannot tell on Memory To-Host, but can for Flash write)"]
 pub type ErrR = crate::FieldReader;
 impl R {
@@ -62,22 +62,22 @@ impl R {
     pub fn intwr(&self) -> IntwrR {
         IntwrR::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 11"]
     #[inline(always)]
     pub fn intspc0(&self) -> Intspc0R {
         Intspc0R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 12"]
     #[inline(always)]
     pub fn intspc1(&self) -> Intspc1R {
         Intspc1R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 13"]
     #[inline(always)]
     pub fn intspc2(&self) -> Intspc2R {
         Intspc2R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 14"]
     #[inline(always)]
     pub fn intspc3(&self) -> Intspc3R {
         Intspc3R::new(((self.bits >> 14) & 1) != 0)
@@ -121,22 +121,22 @@ impl W {
     pub fn intwr(&mut self) -> IntwrW<StatSpec> {
         IntwrW::new(self, 10)
     }
-    #[doc = "Bit 11 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 11"]
     #[inline(always)]
     pub fn intspc0(&mut self) -> Intspc0W<StatSpec> {
         Intspc0W::new(self, 11)
     }
-    #[doc = "Bit 12 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 12"]
     #[inline(always)]
     pub fn intspc1(&mut self) -> Intspc1W<StatSpec> {
         Intspc1W::new(self, 12)
     }
-    #[doc = "Bit 13 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 13"]
     #[inline(always)]
     pub fn intspc2(&mut self) -> Intspc2W<StatSpec> {
         Intspc2W::new(self, 13)
     }
-    #[doc = "Bit 14 - Interrupt was caused by: Bit Endpoint Idx/Data Mbox BusMaster/Flash SPC0 CMD Idx Change Write 0 Completed SPC1 - - Read 0 - SPC2 - - Write Last - SPC3 - - Read Last -"]
+    #[doc = "Bit 14"]
     #[inline(always)]
     pub fn intspc3(&mut self) -> Intspc3W<StatSpec> {
         Intspc3W::new(self, 14)
@@ -153,7 +153,7 @@ impl crate::Readable for StatSpec {}
 impl crate::Writable for StatSpec {
     type Safety = crate::Unsafe;
     const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0x7f00;
 }
 #[doc = "`reset()` method sets STAT to value 0"]
 impl crate::Resettable for StatSpec {


### PR DESCRIPTION
Several bits in PnSTAT register are write-one-to-clear. Mark them accordingly so svd2rust can generate the correct accessors for us.