### PR TITLE
ci: remove per-commit checking from check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,11 +1,7 @@
 # This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
 # several checks:
-# - commit_list: produces a list of commits to be checked
 # - fmt: checks that the code is formatted according to rustfmt
 # - clippy: checks that the code does not contain any clippy warnings
-# - doc: checks that the code can be documented without errors
-# - hack: check combinations of feature flags
-# - msrv: check that the msrv specified in the crate is correct
 permissions:
   contents: read
 # This configuration allows maintainers of this repo to create a branch and pull request based on
@@ -23,47 +19,13 @@ concurrency:
 name: check
 jobs:
 
-  commit_list:
-    runs-on: ubuntu-latest
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Get commit list (push)
-      id: get_commit_list_push
-      if: ${{ github.event_name == 'push' }}
-      run: |
-        echo "id0=$GITHUB_SHA" > $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/OpenDevicePartnership/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    - name: Get commit list (PR)
-      id: get_commit_list_pr
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        git rev-list --reverse refs/remotes/origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | awk '{ print "id" NR "=" $1 }' > $GITHUB_OUTPUT
-        git diff --quiet ${{ github.event.pull_request.head.sha }} ${{ github.sha }} || echo "id0=$GITHUB_SHA" >> $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- https://github.com/OpenDevicePartnership/embassy-imxrt/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    outputs:
-      commits: ${{ toJSON(steps.*.outputs.*) }}
-
   fmt:
     runs-on: ubuntu-latest
     name: nightly / fmt
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -74,7 +36,6 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     name: ${{ matrix.toolchain }} / clippy
-    needs: commit_list
     permissions:
       contents: read
       checks: write
@@ -83,12 +44,10 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,11 @@
 # several checks:
 # - fmt: checks that the code is formatted according to rustfmt
 # - clippy: checks that the code does not contain any clippy warnings
+# - semver: checks for semver compatibility
+# - doc: checks that the code can be documented without errors
+# - hack: check combinations of feature flags
+# - deny: checks licenses, advisories, sources, and bans
+# - msrv: check that the msrv specified in the crate is correct
 permissions:
   contents: read
 # This configuration allows maintainers of this repo to create a branch and pull request based on
@@ -62,16 +67,10 @@ jobs:
   semver:
     runs-on: ubuntu-latest
     name: semver
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -85,16 +84,10 @@ jobs:
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
     name: nightly / doc
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo doc
@@ -107,16 +100,10 @@ jobs:
     # which is required for feature unification
     runs-on: ubuntu-latest
     name: ubuntu / stable / features
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
@@ -131,16 +118,10 @@ jobs:
     # our dependencies.
     runs-on: ubuntu-latest
     name: ubuntu / stable / deny
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-deny
@@ -154,13 +135,10 @@ jobs:
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
-    needs: commit_list
     # we use a matrix here just because env can't be used in job names
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
-      fail-fast: false
       matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
         msrv: ["1.76"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
@@ -174,7 +152,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
+    { id = "RUSTSEC-2026-0110", reason = "bare-metal is deprecated and archived, which cortex-m has a dependency on. Need cortex-m to migrate away from it." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow configuration by removing the custom `commit_list` job and its related logic. The workflow now runs checks directly on the current commit or PR head, streamlining the CI process and reducing complexity.

**Workflow simplification:**

* Removed the `commit_list` job, which previously generated a list of commits to be checked for pushes and pull requests. This includes deleting all related steps and outputs.
* Updated the `fmt` and `clippy` jobs to no longer depend on `commit_list`, eliminating the use of commit matrices and running checks only on the current commit. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L26-L66) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L77) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L86-L91)

**Documentation updates:**

* Updated the workflow comments to reflect the removal of the `commit_list`, `doc`, `hack`, and `msrv` jobs, ensuring that the documentation matches the new workflow structure.